### PR TITLE
Update loader.ts

### DIFF
--- a/lib/loader.spec.ts
+++ b/lib/loader.spec.ts
@@ -9,12 +9,13 @@ describe("TypeScriptLoader", () => {
   const fixturesPath = path.resolve(__dirname, "__fixtures__");
 
   let loader: Loader;
+  let tsNodeSpy = jest.spyOn(tsnode, "register");
 
   function readFixtureContent(file: string): string {
     return fs.readFileSync(file).toString();
   }
 
-  beforeEach(() => {
+  beforeAll(() => {
     loader = TypeScriptLoader();
   });
 
@@ -26,6 +27,14 @@ describe("TypeScriptLoader", () => {
   it("should fail on parsing an invalid TS file", () => {
     const filePath = path.resolve(fixturesPath, "invalid.fixture.ts");
     expect(() => loader(filePath, readFixtureContent(filePath))).toThrowError();
+  });
+
+  it("should use the same instance of ts-node across multiple calls", () => {
+    const filePath = path.resolve(fixturesPath, "valid.fixture.ts");
+    loader(filePath, readFixtureContent(filePath));
+    loader(filePath, readFixtureContent(filePath));
+    loader(filePath, readFixtureContent(filePath));
+    expect(tsNodeSpy).toHaveBeenCalledTimes(1);
   });
 
   it("should throw a TypeScriptCompileError on error", () => {

--- a/lib/loader.spec.ts
+++ b/lib/loader.spec.ts
@@ -7,9 +7,9 @@ import { TypeScriptCompileError } from "./typescript-compile-error";
 
 describe("TypeScriptLoader", () => {
   const fixturesPath = path.resolve(__dirname, "__fixtures__");
+  const tsNodeSpy = jest.spyOn(tsnode, "register");
 
   let loader: Loader;
-  let tsNodeSpy = jest.spyOn(tsnode, "register");
 
   function readFixtureContent(file: string): string {
     return fs.readFileSync(file).toString();
@@ -31,7 +31,6 @@ describe("TypeScriptLoader", () => {
 
   it("should use the same instance of ts-node across multiple calls", () => {
     const filePath = path.resolve(fixturesPath, "valid.fixture.ts");
-    loader(filePath, readFixtureContent(filePath));
     loader(filePath, readFixtureContent(filePath));
     loader(filePath, readFixtureContent(filePath));
     expect(tsNodeSpy).toHaveBeenCalledTimes(1);

--- a/lib/loader.spec.ts
+++ b/lib/loader.spec.ts
@@ -54,10 +54,16 @@ describe("TypeScriptLoader", () => {
     let stub: jest.SpyInstance<tsnode.Service, [service: tsnode.Service]>;
 
     beforeEach(() => {
-      stub = jest.spyOn(tsnode, "register").mockImplementation(() => {
-        // eslint-disable-next-line @typescript-eslint/no-throw-literal
-        throw unknownError;
-      });
+      stub = jest.spyOn(tsnode, "register").mockImplementation(
+        () =>
+          ({
+            compile: (): string => {
+              // eslint-disable-next-line @typescript-eslint/no-throw-literal
+              throw unknownError;
+            },
+          } as any)
+      );
+      loader = TypeScriptLoader();
     });
 
     afterEach(() => {

--- a/lib/loader.ts
+++ b/lib/loader.ts
@@ -3,10 +3,11 @@ import { register, RegisterOptions } from "ts-node";
 import { TypeScriptCompileError } from "./typescript-compile-error";
 
 export function TypeScriptLoader(options?: RegisterOptions): Loader {
+  const tsNodeInstance = register({ ...options, compilerOptions: { module: "commonjs" } })
   return (path: string, content: string) => {
     try {
       // cosmiconfig requires the transpiled configuration to be CJS
-      register({ ...options, compilerOptions: { module: "commonjs" } }).compile(
+      tsNodeInstance.compile(
         content,
         path
       );

--- a/lib/loader.ts
+++ b/lib/loader.ts
@@ -3,14 +3,14 @@ import { register, RegisterOptions } from "ts-node";
 import { TypeScriptCompileError } from "./typescript-compile-error";
 
 export function TypeScriptLoader(options?: RegisterOptions): Loader {
-  const tsNodeInstance = register({ ...options, compilerOptions: { module: "commonjs" } })
+  const tsNodeInstance = register({
+    ...options,
+    compilerOptions: { module: "commonjs" },
+  });
   return (path: string, content: string) => {
     try {
       // cosmiconfig requires the transpiled configuration to be CJS
-      tsNodeInstance.compile(
-        content,
-        path
-      );
+      tsNodeInstance.compile(content, path);
       const result = require(path);
 
       // `default` is used when exporting using export default, some modules


### PR DESCRIPTION
Only create a single instance of ts-node.

We load many configs, we noticed a significant memory leak,  this creates a single instance of ts-node

