### PR TITLE
proof that exports are broken

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,12 @@ jobs:
         id: test
         if: ${{ always() }}
         run: npm run test
+      - name: CJS import
+        run: node smoke-test-cjs.js
+      - name: ESM import
+        run: node smoke-test-esm.mjs
+      - name: CJS and ESM import from CJS
+        run: node smoke-test.js
       - name: lint
         if: ${{ always() }}
         run: npm run lint

--- a/smoke-test-cjs.js
+++ b/smoke-test-cjs.js
@@ -1,0 +1,2 @@
+const TypeScriptLoader = require("./dist/cjs/index.js");
+TypeScriptLoader()

--- a/smoke-test-esm.mjs
+++ b/smoke-test-esm.mjs
@@ -1,0 +1,2 @@
+import TypeScriptLoader from "./dist/cjs/index.js";
+TypeScriptLoader()

--- a/smoke-test.js
+++ b/smoke-test.js
@@ -1,0 +1,14 @@
+const assert = require('node:assert');
+
+async function main() {
+   const TypeScriptLoader1 = await import('./dist/cjs/index.js');
+   const TypeScriptLoader2 = require('./dist/cjs/index.js');
+
+   assert.equal(TypeScriptLoader1.default, TypeScriptLoader2, 'TypeScriptLoader1 === TypeScriptLoader2');
+
+   // try to create loaders
+   TypeScriptLoader1()
+   TypeScriptLoader2()
+}
+
+main()


### PR DESCRIPTION
Proof that the current default export is broken and only works when consumed from within TypeScript, but not vanilla Node.js

See https://github.com/Codex-/cosmiconfig-typescript-loader/pull/37 for a breaking change "solution" by switching to named exports.